### PR TITLE
feat(p2p-wss): refine p2p-forge and pebble setup for autotls

### DIFF
--- a/beelocal.sh
+++ b/beelocal.sh
@@ -128,6 +128,9 @@ config() {
             sudo cp "${BEE_TEMP}"/registries.yaml /etc/rancher/k3s/registries.yaml
         fi
         BEE_CONFIG="${BEE_TEMP}"
+    else
+        # Use local config files
+        BEE_CONFIG="config"
     fi
 }
 
@@ -317,10 +320,11 @@ deploy-p2p-wss() {
         echo "CoreDNS already configured for local.test, skipping..."
     else
         # Patch CoreDNS configmap to add local.test forwarding
+        P2P_FORGE_IP=$(kubectl get svc p2p-forge -n "${NAMESPACE}" -o jsonpath='{.spec.clusterIP}')
         LOCAL_TEST_BLOCK="local.test:53 {
     errors
     cache 30
-    forward . p2p-forge.${NAMESPACE}.svc.cluster.local:53
+    forward . ${P2P_FORGE_IP}:53
 }"
         # Get current Corefile, append local.test block, and apply
         CURRENT_COREFILE=$(kubectl get cm coredns -n kube-system -o jsonpath='{.data.Corefile}')

--- a/beelocal.sh
+++ b/beelocal.sh
@@ -309,6 +309,33 @@ deploy-p2p-wss() {
     echo "waiting for p2p-forge to be ready..."
     kubectl rollout status deployment/p2p-forge -n "${NAMESPACE}" --timeout=120s || true
     
+    # Configure CoreDNS to forward local.test queries to p2p-forge
+    echo "configuring CoreDNS to forward local.test to p2p-forge..."
+    
+    # Check if local.test forwarding is already configured
+    if kubectl get cm coredns -n kube-system -o jsonpath='{.data.Corefile}' | grep -q "local.test"; then
+        echo "CoreDNS already configured for local.test, skipping..."
+    else
+        # Patch CoreDNS configmap to add local.test forwarding
+        LOCAL_TEST_BLOCK="local.test:53 {
+    errors
+    cache 30
+    forward . p2p-forge.${NAMESPACE}.svc.cluster.local:53
+}"
+        # Get current Corefile, append local.test block, and apply
+        CURRENT_COREFILE=$(kubectl get cm coredns -n kube-system -o jsonpath='{.data.Corefile}')
+        NEW_COREFILE="${CURRENT_COREFILE}
+${LOCAL_TEST_BLOCK}"
+        
+        kubectl create configmap coredns -n kube-system \
+            --from-literal=Corefile="${NEW_COREFILE}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+        
+        kubectl rollout restart deployment coredns -n kube-system
+        kubectl rollout status deployment/coredns -n kube-system --timeout=60s || true
+        echo "CoreDNS configured for local.test forwarding..."
+    fi
+    
     echo "Pebble and p2p-forge deployed successfully..."
 }
 

--- a/config/p2p-forge-deployment.yaml
+++ b/config/p2p-forge-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: p2p-forge-config
-  namespace: local
+  namespace: local-dns
 data:
   Corefile: |
     .:53 {
@@ -18,7 +18,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: p2p-forge
-  namespace: local
+  namespace: local-dns
   labels:
     app: p2p-forge
 spec:
@@ -67,7 +67,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: p2p-forge
-  namespace: local
+  namespace: local-dns
   labels:
     app: p2p-forge
 spec:

--- a/config/p2p-forge-deployment.yaml
+++ b/config/p2p-forge-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: p2p-forge-config
-  namespace: local-dns
+  namespace: local
 data:
   Corefile: |
     .:53 {
@@ -18,7 +18,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: p2p-forge
-  namespace: local-dns
+  namespace: local
   labels:
     app: p2p-forge
 spec:
@@ -67,7 +67,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: p2p-forge
-  namespace: local-dns
+  namespace: local
   labels:
     app: p2p-forge
 spec:

--- a/config/p2p-forge-deployment.yaml
+++ b/config/p2p-forge-deployment.yaml
@@ -9,7 +9,7 @@ data:
         errors
         log
         acme local.test {
-            registration-domain p2p-forge listen-address=:8080 external-tls=false
+            registration-domain p2p-forge.local.svc.cluster.local:8080 listen-address=:8080 external-tls=true
             database-type badger /data
         }
     }

--- a/config/pebble-deployment.yaml
+++ b/config/pebble-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pebble-config
-  namespace: local-dns
+  namespace: local
 data:
   pebble-config.json: |
     {
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pebble
-  namespace: local-dns
+  namespace: local
   labels:
     app: pebble
 spec:
@@ -78,7 +78,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pebble
-  namespace: local-dns
+  namespace: local
   labels:
     app: pebble
 spec:

--- a/config/pebble-deployment.yaml
+++ b/config/pebble-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pebble-config
-  namespace: local
+  namespace: local-dns
 data:
   pebble-config.json: |
     {
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pebble
-  namespace: local
+  namespace: local-dns
   labels:
     app: pebble
 spec:
@@ -78,7 +78,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pebble
-  namespace: local
+  namespace: local-dns
   labels:
     app: pebble
 spec:


### PR DESCRIPTION
## Description
This PR adds automatic CoreDNS configuration to forward `local.test` DNS queries to p2p-forge, enabling proper ACME challenge resolution for P2P-WSS certificates.

### Changes

- **beelocal.sh**: 
  - Add support for `LOCAL_CONFIG` environment variable to use local config files
  - Add CoreDNS configuration in `deploy-p2p-wss()` to forward `local.test` queries to p2p-forge service

- **config/p2p-forge-deployment.yaml**:
  - Update registration domain to use full cluster DNS name (`p2p-forge.local.svc.cluster.local:8080`)
  - Enable external TLS (`external-tls=true`)

### How to Test

```
ACTION=prepare OPTS='skip-vet' P2P_WSS_ENABLE=true BEELOCAL_BRANCH=akrem/p2p-wss-support-v2 ./beelocal.sh
```